### PR TITLE
databinding 설정과 gradle에 dependency 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,11 +1,13 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("kotlin-kapt")
+    id("com.google.dagger.hilt.android")
 }
 
 android {
     namespace = "com.jaewchoi.barcodescanner"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "com.jaewchoi.barcodescanner"
@@ -33,15 +35,47 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+    buildFeatures {
+        dataBinding = true
+    }
 }
 
 dependencies {
+    val kotlinVersion: String by project
+    val appCompatVersion: String by project
+    val materialVersion: String by project
+    val constraintLayoutVersion: String by project
+    val junitVersion: String by project
+    val testExtJunitVersion: String by project
+    val espressoVersion: String by project
+    val viewModelKtxVersion: String by project
+    val activityKtxVersion: String by project
+    val fragmentKtxVersion: String by project
+    val coroutineVersion: String by project
+    val retrofitVersion: String by project
+    val hiltVersion: String by project
 
-    implementation("androidx.core:core-ktx:1.9.0")
-    implementation("androidx.appcompat:appcompat:1.7.0")
-    implementation("com.google.android.material:material:1.12.0")
-    implementation("androidx.constraintlayout:constraintlayout:2.2.1")
-    testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.2.1")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    implementation("androidx.core:core-ktx:$kotlinVersion")
+    implementation("androidx.appcompat:appcompat:$appCompatVersion")
+    implementation("com.google.android.material:material:$materialVersion")
+    implementation("androidx.constraintlayout:constraintlayout:$constraintLayoutVersion")
+    testImplementation("junit:junit:$junitVersion")
+    androidTestImplementation("androidx.test.ext:junit:$testExtJunitVersion")
+    androidTestImplementation("androidx.test.espresso:espresso-core:$espressoVersion")
+
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:$viewModelKtxVersion")
+    implementation("androidx.activity:activity-ktx:$activityKtxVersion")
+    implementation("androidx.fragment:fragment-ktx:$fragmentKtxVersion")
+
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutineVersion")
+
+    implementation("com.squareup.retrofit2:retrofit:$retrofitVersion")
+    implementation("com.squareup.retrofit2:converter-gson:$retrofitVersion")
+
+    implementation("com.google.dagger:hilt-android:$hiltVersion")
+    kapt("com.google.dagger:hilt-android-compiler:$hiltVersion")
+}
+
+kapt {
+    correctErrorTypes = true
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.1.1" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.0" apply false
+    id("com.android.application") apply false
+    id("org.jetbrains.kotlin.android") apply false
+    id("com.google.dagger.hilt.android") apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,20 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+
+# app dependencies version
+kotlinVersion=1.9.0
+applicationVersion=8.1.1
+appCompatVersion=1.7.0
+materialVersion=1.12.0
+constraintLayoutVersion=2.2.1
+junitVersion=4.13.2
+testExtJunitVersion=1.2.1
+espressoVersion=3.6.1
+viewModelKtxVersion=2.8.7
+activityKtxVersion=1.9.0
+fragmentKtxVersion=1.8.6
+coroutineVersion=1.7.3
+retrofitVersion=2.11.0
+hiltVersion=2.51.1

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,10 +1,20 @@
 pluginManagement {
+    val kotlinVersion: String by settings
+    val applicationVersion: String by settings
+    val hiltVersion: String by settings
+
     repositories {
         google()
         mavenCentral()
         gradlePluginPortal()
     }
+    plugins {
+        id("org.jetbrains.kotlin.android") version kotlinVersion
+        id("com.android.application") version applicationVersion
+        id("com.google.dagger.hilt.android") version hiltVersion
+    }
 }
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {


### PR DESCRIPTION
# dependency 버전
- 각 라이브러리의 버전은 gradle.properties 파일에서 지정합니다.
- build.gradle 에서는 gradle.properties 파일에 저장된 라이브러리 버전을 참조해서 사용합니다.
- 기존 project level build.gradle 에서 지정하던 버전은 settings.gradle 파일에서 지정합니다.

# dependency 추가
- activity-ktx, viewmodel-ktx, retrofit 등 필요한 dependency를 추가했습니다.